### PR TITLE
Reduce amount of spam caused by GDPR notice.

### DIFF
--- a/src/trigger/rodo.rs
+++ b/src/trigger/rodo.rs
@@ -24,7 +24,7 @@ p.niemiec"#
     }
 
     fn frequency() -> i32 {
-        40
+        20
     }
 
     fn contains_trigger(content: &str) -> bool {


### PR DESCRIPTION
Right now, Janosik spams after random messages which are unrelated to GDPR. It's a temporary solution while SimSearch isn't accurate.